### PR TITLE
remove codecov from build&deploy docs

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -33,7 +33,7 @@ jobs:
           source $(poetry env info --path)/bin/activate
           poetry install --with docs,test
           cd docs && rm -rf source/reference/api/_autosummary && make html
-          cd .. && coverage run -m pytest -m "not integration_test" && coverage xml && coverage report -m
+          # cd .. && coverage run -m pytest -m "not integration_test" && coverage xml && coverage report -m
       # - name: Upload coverage to Codecov
       #   uses: Wandalen/wretry.action@v1.4.4
       #   with:


### PR DESCRIPTION
# Fix

# Short Description
- Adjust ```docs_deploy.yml``` and ```docs_build.yml``` to remove codecov calls, will add back later once integration is fixed.

# Tests Added
No tests added.
